### PR TITLE
PN-115 Have the `request` method return JSON.

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -17,11 +17,8 @@ export default (host: string) => {
                     },
                 );
 
-                if (response) {
-                    console.log(response);
-                    const message = response;
-                    return message;
-                }
+                const data = await response.json();
+                return data;
             } catch (error) {
                 console.error(error);
                 return error;


### PR DESCRIPTION
Without await response.json(), the client was getting undefined as a response.