### PR TITLE
PN-111 Make response EIP-1193 compliant.

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,28 +1,32 @@
 export default (host: string) => {
     return {
         request: async function (request: any) {
-            try {
-                // @ts-ignore, https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#xhr_and_fetch
-                const response = await window.top.fetch(
-                    `${host}/v1/api/blockchain`,
-                    {
-                        method: "POST",
-                        cache: "no-cache",
-                        credentials: "include",
-                        keepalive: true,
-                        headers: {
-                            "Content-Type": "application/json",
-                        },
-                        body: JSON.stringify(request),
+            // @ts-ignore, https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#xhr_and_fetch
+            const response = await window.top.fetch(
+                `${host}/v1/api/blockchain`,
+                {
+                    method: "POST",
+                    cache: "no-cache",
+                    credentials: "include",
+                    keepalive: true,
+                    headers: {
+                        "Content-Type": "application/json",
                     },
-                );
+                    body: JSON.stringify(request),
+                },
+            );
 
-                const data = await response.json();
-                return data;
-            } catch (error) {
-                console.error(error);
-                return error;
+            const data = await response.json();
+            console.log(data);
+
+            if (!response.ok) {
+                throw new Error(data.message);
             }
+            if (!data.result) {
+                throw new Error("No `result` returned from RPC method.");
+            }
+
+            return data.result;
         },
     };
 };


### PR DESCRIPTION
After carefully going through EIP-1193 and making test integrations with web3.js and ethers, I realized the response was not in the expected format.

Also, I think it's a little clearer to throw errors. EIP-1193 talks about rejecting, so it's probably better to just throw if we encounter an error.