### PR TITLE
Add a hardcoded Authorization header to the fetch calls

### DIFF
--- a/src/pointsdk/index.ts
+++ b/src/pointsdk/index.ts
@@ -27,7 +27,7 @@ export default (host: string, version: string): PointType => {
 
     // const getAuthHeaders = () => ({ Authorization: 'Basic ' + btoa('WALLETID-PASSCODE') });
     const getAuthHeaders = (): HeadersInit => ({
-        "wallet-token": "WALLETID-PASSCODE",
+        Authorization: "Bearer POINTSDK_TOKEN",
     });
 
     const apiCall = async <T>(path: string, config?: RequestInit) => {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -12,6 +12,7 @@ export default (host: string) => {
                         keepalive: true,
                         headers: {
                             "Content-Type": "application/json",
+                            Authorization: "Bearer POINTSDK_TOKEN",
                         },
                         body: JSON.stringify(request),
                     },


### PR DESCRIPTION
Adds a hardcoded header `Authorization: Bearer POINTSDK_TOKEN` to the fetch calls made by the SDK.