### PR TITLE
PN-124 Add `send` method for `web3-react`

### DIFF
--- a/src/pointsdk/provider.ts
+++ b/src/pointsdk/provider.ts
@@ -1,35 +1,39 @@
 const getProvider = () => {
-    return {
-        request: (request: Record<string, any>) =>
-            new Promise((resolve, reject) => {
-                const id = Math.random();
+    function handleRequest(request: Record<string, any>) {
+        return new Promise((resolve, reject) => {
+            const id = Math.random();
 
-                const handler = (e: MessageEvent) => {
-                    if (
-                        e.data.__page_req_id === id &&
-                        e.data.__direction === "to_page"
-                    ) {
-                        window.removeEventListener("message", handler);
-                        if (e.data.code) {
-                            reject({
-                                code: e.data.code,
-                                message: e.data.message,
-                            });
-                        } else {
-                            resolve(e.data.result);
-                        }
+            const handler = (e: MessageEvent) => {
+                if (
+                    e.data.__page_req_id === id &&
+                    e.data.__direction === "to_page"
+                ) {
+                    window.removeEventListener("message", handler);
+                    if (e.data.code) {
+                        reject({
+                            code: e.data.code,
+                            message: e.data.message,
+                        });
+                    } else {
+                        resolve(e.data.result);
                     }
-                };
+                }
+            };
 
-                window.addEventListener("message", handler);
+            window.addEventListener("message", handler);
 
-                window.postMessage({
-                    ...request,
-                    __message_type: "rpc",
-                    __page_req_id: id,
-                    __direction: "to_bg",
-                });
-            }),
+            window.postMessage({
+                ...request,
+                __message_type: "rpc",
+                __page_req_id: id,
+                __direction: "to_bg",
+            });
+        });
+    }
+
+    return {
+        request: handleRequest,
+        send: (method: string) => handleRequest({ method }),
     };
 };
 


### PR DESCRIPTION
To connect a wallet using `web3-react` library with the
`window.ethereum` provider injected by PointSDK, a
`window.ethereum.send` method is required.

`web3-react`'s Injected Connector calls `send` instead of `request`
for some RPC calls, most notably: `eth_requestAccounts`, which is
called as part of the wallet-connection process.

https://user-images.githubusercontent.com/101118664/165559085-de1d48dc-1a50-40b3-8f44-8dd73a639f9e.mp4
