### PR TITLE
Change connection URL and path to allow connectivity with Point Node

### DIFF
--- a/src/pointsdk/sdk.ts
+++ b/src/pointsdk/sdk.ts
@@ -216,7 +216,7 @@ const getSdk = (host: string, version: string): PointType => {
                 return;
             }
 
-            const ws = new WebSocket(host);
+            const ws = new WebSocket(`${host}ws?token=POINTSDK_TOKEN`);
 
             ws.onopen = () =>
                 resolve(


### PR DESCRIPTION
This PR includes a small change to allow ZApps to listen to smartcontract events through window.point.contract.subscribe

- Changed the connection location and included the authentication token (currently hardcoded)