### PR TITLE
PN-181 Do not reject if WS is closed due to page refresh

### DIFF
--- a/src/pointsdk/sdk.ts
+++ b/src/pointsdk/sdk.ts
@@ -308,17 +308,17 @@ const getSdk = (host: string, version: string): PointType => {
 
             ws.onclose = (e) => {
                 delete socketsByHost[host];
-
-                for (const queueId in messagesBySubscriptionId) {
-                    if (!errorsBySubscriptionId[queueId]) {
-                        errorsBySubscriptionId[queueId] =
-                            new ZProxyWSConnectionClosed(e.toString());
-                    }
-                }
-
-                if (e.code === 1000) {
+                if (e.code === 1000 || e.code === 1001) {
+                    // 1000 -> CLOSE_NORMAL (normal socket shut down)
+                    // 1001 -> CLOSE_GOING_AWAY (closing browser tab, refreshing, navigating away)
                     resolve(undefined); // closed intentionally
                 } else {
+                    for (const queueId in messagesBySubscriptionId) {
+                        if (!errorsBySubscriptionId[queueId]) {
+                            errorsBySubscriptionId[queueId] =
+                                new ZProxyWSConnectionClosed(e.toString());
+                        }
+                    }
                     reject();
                 }
             };


### PR DESCRIPTION
If the websocket is closed with error **1001**, do not reject as this error means "going away", it's triggered, among other things, by refreshing the page.

I propose not to add an error to the `errorsBySubscriptionId` map when the websocket connection is closed with either **1000** or **1001**, as these are not errors we should worry about.

Before these changes, you could see an "unhandled rejection" in the console after refreshing a dApp that uses a WS connection:
![Screenshot from 2022-07-05 12-23-39](https://user-images.githubusercontent.com/101118664/177366609-b2516089-df48-40ca-9152-0b340e081b23.png)


The WS connection being closed on page refresh is expected behaviour. I tested that after refreshing, the connection gets re-established, and that is the case. It reconnects.