### PR TITLE
PN-198 Add method to fetch identity data of current user

### DIFF
--- a/src/pointsdk/index.d.ts
+++ b/src/pointsdk/index.d.ts
@@ -101,6 +101,14 @@ export type ZProxyWS = WebSocket & {
     ) => Promise<() => Promise<T>>;
 };
 
+export type IdentityData = {
+    identityRegistred: boolean;
+    identity: string;
+    address: string;
+    publicKey: string;
+    network: "solana" | "ethereum" | "point";
+};
+
 export type PointType = {
     version: string;
     status: {
@@ -135,5 +143,6 @@ export type PointType = {
         publicKeyByIdentity: <T>(
             request: PublicKeyByIdentityRequest,
         ) => Promise<T>;
+        me: () => Promise<IdentityData>;
     };
 };

--- a/src/pointsdk/sdk.ts
+++ b/src/pointsdk/sdk.ts
@@ -20,6 +20,7 @@ import {
     SubscriptionMessages,
     SubscriptionEvent,
     SubscriptionParams,
+    IdentityData,
 } from "./index.d";
 
 const getSdk = (host: string, version: string): PointType => {
@@ -766,6 +767,12 @@ const getSdk = (host: string, version: string): PointType => {
                 api.get<T>(
                     `identity/ownerToIdentity/${owner}`,
                     args,
+                    getAuthHeaders(),
+                ),
+            me: () =>
+                api.get<IdentityData>(
+                    "identity/isIdentityRegistered/",
+                    undefined,
                     getAuthHeaders(),
                 ),
         },


### PR DESCRIPTION
The idea is to provide a single method that would collect some useful public information about the current user. This should facilitate working with SNS and ENS identities.

Please refer to [the ticket](https://point-labs.atlassian.net/browse/PN-198) for further details.