### PR TITLE
PN-200 Show decoded tx data in ConfirmationWindow

### DIFF
--- a/src/background/confirmationWindowApi.ts
+++ b/src/background/confirmationWindowApi.ts
@@ -7,14 +7,21 @@ export const displayConfirmationWindow = async (
     host: string,
     network: string,
     params = {},
+    decodedTxData = {},
 ) => {
+    const query = new URLSearchParams();
+    query.append("reqId", reqId);
+    query.append("pointId", pointId);
+    query.append("host", host);
+    query.append("network", network);
+    query.append("params", JSON.stringify(params));
+    query.append("decodedTxData", JSON.stringify(decodedTxData));
+
     const win = await browser.windows.create({
         type: "detached_panel",
-        url: `./confirmation-window/index.html?reqId=${reqId}&pointId=${pointId}&host=${host}&network=${network}&params=${encodeURIComponent(
-            JSON.stringify(params),
-        )}`,
         width: 400,
         height: 600,
+        url: `./confirmation-window/index.html?${query.toString()}`,
     });
     windowId = win.id!;
 };

--- a/src/background/messaging.ts
+++ b/src/background/messaging.ts
@@ -42,6 +42,7 @@ socket.onmessage = (e) => {
                 payload.request.__hostname,
                 payload.data.network,
                 params,
+                payload.data.decodedTxData,
             );
         } else {
             responseHandlers[payload.request.__point_id](payload.data);

--- a/src/confirmation-window/ConfirmationWindow.tsx
+++ b/src/confirmation-window/ConfirmationWindow.tsx
@@ -12,6 +12,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 import useConfirmationWindow from "./hook";
 import { useLocation } from "react-router-dom";
 import browser from "webextension-polyfill";
+import { DecodedTxInput } from "../pointsdk/index.d";
 
 const theme = createTheme({
     typography: {
@@ -32,9 +33,20 @@ const ConfirmationWindow = () => {
         () => JSON.parse(decodeURIComponent(query.get("params") as string)),
         [query],
     );
+
+    const decodedTxData = useMemo((): DecodedTxInput | null => {
+        try {
+            const str = query.get("decodedTxData");
+            return str ? (JSON.parse(str) as DecodedTxInput) : null;
+        } catch {
+            return null;
+        }
+    }, [query]);
+
     const { params, loading } = useConfirmationWindow(
         rawParams,
         query.get("network") as string,
+        decodedTxData,
     );
 
     const handleAllow: ReactEventHandler = async () => {

--- a/src/pointsdk/index.d.ts
+++ b/src/pointsdk/index.d.ts
@@ -26,6 +26,7 @@ export type ContractSendRequest = {
     method: string;
     params?: unknown[];
     value: string;
+    meta?: Record<string, string>;
 };
 
 export type WalletSendRequest = {
@@ -145,4 +146,15 @@ export type PointType = {
         ) => Promise<T>;
         me: () => Promise<IdentityData>;
     };
+};
+
+type Param = {
+    name: string;
+    value: string;
+    type: string;
+};
+
+export type DecodedTxInput = {
+    name: string;
+    params: Param[];
 };

--- a/src/pointsdk/sdk.ts
+++ b/src/pointsdk/sdk.ts
@@ -619,6 +619,7 @@ const getSdk = (host: string, version: string): PointType => {
                 });
 
                 return window.top.ethereum.request({
+                    meta: { contract },
                     method: "eth_sendTransaction",
                     params: [
                         {


### PR DESCRIPTION
If Point Engine provides _decoded tx input data_ in RPC responses to `eth_sendTransaction`, it will be displayed in the confirmation window. Below, the raw data will also be displayed. If no decoded data is available, just the raw data will be displayed.

![Screenshot from 2022-08-03 14-53-30](https://user-images.githubusercontent.com/101118664/182682980-efa7e3e3-d55a-4b94-a78e-092c3747540b.png)

