### PR TITLE
PN-262 Enrich tx input information

### DIFF
--- a/src/confirmation-window/components/DecodedData.tsx
+++ b/src/confirmation-window/components/DecodedData.tsx
@@ -3,6 +3,7 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import useTheme from "@mui/material/styles/useTheme";
 import Label from "./Label";
+import TxParamValue from "./TxParamValue";
 import { DecodedTxInput } from "../../pointsdk/index.d";
 
 type Props = {
@@ -52,7 +53,7 @@ const DecodedData = ({ data }: Props) => {
                                         wordWrap: "break-word",
                                     }}
                                 >
-                                    {p.name}: {p.value}
+                                    {p.name}: <TxParamValue param={p} />
                                 </Typography>
                             </li>
                         ))}

--- a/src/confirmation-window/components/TxParamValue.tsx
+++ b/src/confirmation-window/components/TxParamValue.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { Param, ParamMetaType } from "../../pointsdk/index.d";
+
+type Props = { param: Param };
+
+const TxParamValue = ({ param }: Props) => {
+    switch (param.meta?.type) {
+        case ParamMetaType.ZERO_CONTENT:
+            return <span>no content</span>;
+        case ParamMetaType.STORAGE_ID:
+            return (
+                <a
+                    href={`https://point/_storage/${param.value}`}
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    content in storage &rarr; {param.value}
+                </a>
+            );
+        case ParamMetaType.TX_HASH:
+            return (
+                <span>Blockchain Transaction Hash &rarr; {param.value}</span>
+            );
+        case ParamMetaType.NOT_FOUND:
+            return (
+                <span>
+                    {param.value} <em>(not found in storage nor blockchain)</em>
+                </span>
+            );
+        default:
+            return <span>{param.value}</span>;
+    }
+};
+
+export default TxParamValue;

--- a/src/pointsdk/index.d.ts
+++ b/src/pointsdk/index.d.ts
@@ -163,10 +163,20 @@ export type PointType = {
     };
 };
 
-type Param = {
+export enum ParamMetaType {
+    STORAGE_ID = "storage_id",
+    ZERO_CONTENT = "zero_content",
+    TX_HASH = "tx_hash",
+    NOT_FOUND = "not_found",
+}
+
+export type Param = {
     name: string;
     value: string;
     type: string;
+    meta?: {
+        type: ParamMetaType;
+    };
 };
 
 export type DecodedTxInput = {


### PR DESCRIPTION
If Point Engine sends any metadata attached to the transaction input that the user is asked to review and approve, these changes will present such metadata in a user-friendly way in the confirmation window.

- If the input is an empty hash (_0x000..._), we will show a "no content" message instead of all the zeros.
- If the input is a storage ID, we will provide a link to `/_storage/:id` that will open in a new tab.
- If the input is a blockchain transaction, we will include a message saying so (in the future, when we have an explorer in Point Network, we can convert it to a link to the transaction in said explorer).
- If the input looks like a storage ID/tx hash, but is none, we will show a "not found" message.

Here are some screenshots (please mind that the `wtf` input in some of the screenshots has been manually added in the code just for testing, to simulate found and not-found blockchain transactions).

![not_found](https://user-images.githubusercontent.com/101118664/196279547-edd01110-4ac8-4aa7-8d34-8fb1cecd74d0.png)

![storage](https://user-images.githubusercontent.com/101118664/196279615-15fe15e8-8ab8-4efc-8840-f37fa0a101a4.png)

![tx](https://user-images.githubusercontent.com/101118664/196279625-df27ef52-1a01-44b5-9ad8-cf14b01a00ad.png)
