### PR TITLE
PN-265 Show identities in confirmation window

### DIFF
--- a/src/confirmation-window/components/TxDetails.tsx
+++ b/src/confirmation-window/components/TxDetails.tsx
@@ -39,6 +39,7 @@ const TxDetails = ({ rawParams, decodedTxData, network }: Props) => {
                 switch (key) {
                     case "from":
                     case "to":
+                    case "beneficiary":
                         return (
                             <Address key={idx} label={key} address={value} />
                         );
@@ -55,7 +56,10 @@ const TxDetails = ({ rawParams, decodedTxData, network }: Props) => {
                             />
                         );
                     case "data":
-                        if (decodedTxData) {
+                        if (
+                            decodedTxData &&
+                            JSON.stringify(decodedTxData) !== "{}"
+                        ) {
                             return (
                                 <Fragment key={idx}>
                                     <DecodedData data={decodedTxData} />
@@ -65,7 +69,8 @@ const TxDetails = ({ rawParams, decodedTxData, network }: Props) => {
                         }
                         return <RawData key={idx} label={key} data={value} />;
                     case "domain":
-                        return decodedTxData ? (
+                        return decodedTxData &&
+                            JSON.stringify(decodedTxData) !== "{}" ? (
                             <DecodedData data={decodedTxData} />
                         ) : null;
                     default:

--- a/src/confirmation-window/components/TxParamValue.tsx
+++ b/src/confirmation-window/components/TxParamValue.tsx
@@ -1,9 +1,13 @@
 import React from "react";
+import Typography from "@mui/material/Typography";
+import useTheme from "@mui/material/styles/useTheme";
 import { Param, ParamMetaType } from "../../pointsdk/index.d";
 
 type Props = { param: Param };
 
 const TxParamValue = ({ param }: Props) => {
+    const theme = useTheme();
+
     switch (param.meta?.type) {
         case ParamMetaType.ZERO_CONTENT:
             return <span>no content</span>;
@@ -26,6 +30,21 @@ const TxParamValue = ({ param }: Props) => {
                 <span>
                     {param.value} <em>(not found in storage nor blockchain)</em>
                 </span>
+            );
+        case ParamMetaType.IDENTITIES:
+            return (
+                <ul style={{ marginLeft: 24 }}>
+                    {(param.meta.identities || []).map((identity) => (
+                        <li key={identity}>
+                            <Typography
+                                fontSize="inherit"
+                                color={theme.palette.primary.main}
+                            >
+                                @{identity}
+                            </Typography>
+                        </li>
+                    ))}
+                </ul>
             );
         default:
             return <span>{param.value}</span>;

--- a/src/confirmation-window/components/TxParamValue.tsx
+++ b/src/confirmation-window/components/TxParamValue.tsx
@@ -38,9 +38,10 @@ const TxParamValue = ({ param }: Props) => {
                         <li key={identity}>
                             <Typography
                                 fontSize="inherit"
-                                color={theme.palette.primary.main}
+                                fontWeight="normal"
+                                color={theme.palette.text.primary}
                             >
-                                @{identity}
+                                {identity}
                             </Typography>
                         </li>
                     ))}

--- a/src/pointsdk/index.d.ts
+++ b/src/pointsdk/index.d.ts
@@ -168,6 +168,7 @@ export enum ParamMetaType {
     ZERO_CONTENT = "zero_content",
     TX_HASH = "tx_hash",
     NOT_FOUND = "not_found",
+    IDENTITIES = "identities",
 }
 
 export type Param = {
@@ -176,6 +177,7 @@ export type Param = {
     type: string;
     meta?: {
         type: ParamMetaType;
+        identities?: string[];
     };
 };
 


### PR DESCRIPTION
There are two changes related to identities implemented here:

## Identities in transaction input

If one of the inputs of a transaction is an identity, the identity will be shown instead of the address.

Before:
![before](https://user-images.githubusercontent.com/101118664/196528097-84e26dca-2c1d-4e53-9f71-ce0a41b9cf3f.png)

After:
![after](https://user-images.githubusercontent.com/101118664/196528113-720cd200-32d9-4b11-a6c5-dda3f132fcc0.png)

## Beneficiary of token transfer

For token transfers, the beneficiary was not shown in any form. Now, if it's an identity, the identity will be displayed, and if it's not an identity, the address will be displayed.

Before:
![erc20_before](https://user-images.githubusercontent.com/101118664/196528306-90fbb0d5-dceb-4d31-a358-6fcdbbc74364.png)

After:
![erc20_after](https://user-images.githubusercontent.com/101118664/196528325-59d28748-3ae1-4c7a-bcd4-a15121d13bd9.png)
