### PR TITLE
PN-272 Provide initial event-subscription functionality (disabled)

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -6,6 +6,8 @@ import {
     setAuthTokenHandler,
     getAuthToken
 } from 'pointsdk/background/messaging';
+import subscriptionsController from '../event-subscription/controller';
+import {SUBSCRIPTION_MESSAGE_TYPE} from '../event-subscription/types';
 
 const setChainIds = async () => {
     try {
@@ -58,6 +60,8 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
             return setAuthTokenHandler(message);
         case 'getAuthToken':
             return getAuthToken();
+        case SUBSCRIPTION_MESSAGE_TYPE:
+            return subscriptionsController.handleMessage(message);
         default:
             if (sender.url?.match('confirmation-window')) {
                 return confirmationWindowListener(message);
@@ -65,3 +69,5 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
             console.error('Unexpected runtime message: ', message, ' from sender: ', sender);
     }
 });
+
+subscriptionsController.init();

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -70,4 +70,5 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
     }
 });
 
-subscriptionsController.init();
+// Uncomment the next line to enable the event-subscription feature.
+// subscriptionsController.init();

--- a/src/event-subscription/controller.ts
+++ b/src/event-subscription/controller.ts
@@ -1,0 +1,213 @@
+import browser from 'webextension-polyfill';
+import {
+    SubscriptionMessage,
+    SubscriptionMessageMethod,
+    SUBSCRIPTION_STORAGE_KEY,
+    SubscriptionPreferences,
+    EmptyObj,
+    ApiResponse,
+    ContractEvent
+} from './types';
+import {nowIsAfter, nowPlusDays} from '../utils/date';
+
+class SubscriptionsController {
+    private eventsByHost: Record<string, ContractEvent[]> = {};
+    private currentWindow: {host: string; id: number} | null = null;
+
+    /**
+     * Attaches listener to detect visits to dApps and check if the contracts
+     * they use have any events users could subscribe to.
+     */
+    init() {
+        browser.history.onVisited.addListener((historyItem: browser.History.HistoryItem) => {
+            void this.handleVisit(historyItem);
+        });
+    }
+
+    /**
+     * Handler that checks if the visited page is `.point` and, if so, fires a request
+     * to get a list of events implemented in the smart contract (if any).
+     */
+    private handleVisit = async (historyItem: browser.History.HistoryItem) => {
+        try {
+            const {host} = new URL(historyItem.url ?? '');
+            if (host.endsWith('.point')) {
+                // Check user preferences about being asked.
+                const preferences = await this.loadPreferencesForHost(host);
+                if (!preferences || nowIsAfter(preferences.doNotAskBefore)) {
+                    void this.getEvents(host);
+                }
+            }
+        } catch {
+            // `historyItem.url` is not a proper URL, so we simply ignore it.
+        }
+    };
+
+    /**
+     * Retrieves preferences stored in extension storage and returns the ones
+     * corresponding to the given host.
+     */
+    private async loadPreferencesForHost(host: string) {
+        const preferences = (await browser.storage.local.get(SUBSCRIPTION_STORAGE_KEY)) as
+            | {[SUBSCRIPTION_STORAGE_KEY]: SubscriptionPreferences}
+            | EmptyObj;
+
+        if (JSON.stringify(preferences) === '{}') {
+            return undefined;
+        }
+
+        return preferences[SUBSCRIPTION_STORAGE_KEY][host];
+    }
+
+    /**
+     * Flatten ContractEvent data into a string[].
+     */
+    private flatten(data: ContractEvent[]): string[] {
+        const result: string[] = [];
+        data.forEach(i => {
+            i.events.forEach(e => result.push(`${i.contractName}:${e}`));
+        });
+        return result;
+    }
+
+    /**
+     * Turned previously flattened ContractEvent data back into its original form.
+     */
+    private expand(data: string[]): ContractEvent[] {
+        const eventsByContract: Record<string, string[]> = {};
+        data.forEach(str => {
+            const parts = str.split(':');
+            if (parts.length >= 2) {
+                const contract = parts.shift()!;
+                const event = parts.join(':');
+                if (eventsByContract[contract]) {
+                    eventsByContract[contract]!.push(event);
+                } else {
+                    eventsByContract[contract] = [event];
+                }
+            }
+        });
+        return Object.entries(eventsByContract).map(([k, v]) => ({contractName: k, events: v}));
+    }
+
+    /**
+     * Gets events for a given host.
+     * If host has been visited before, the events are cached, if not, they
+     * will be requested from Point Engine.
+     */
+    async getEvents(host: string) {
+        try {
+            if (!this.eventsByHost[host]) {
+                const resp = await window.top.fetch(
+                    `https://point/v1/api/contract/listEvents/${host.replace(/.point$/, '')}`
+                );
+
+                const {data: events} = (await resp.json()) as ApiResponse<ContractEvent[]>;
+                this.eventsByHost[host] = events;
+            }
+
+            if (this.eventsByHost[host]?.length !== 0) {
+                void this.renderUI(host);
+            }
+        } catch {
+            // If there's an error getting events, we don't cache anything, so on the next
+            // visit to the same host, another attempt is made at getting the events.
+        }
+    }
+
+    /**
+     * Renders UI for users to decide if they wish to subscribe to any events.
+     */
+    async renderUI(host: string) {
+        // Make sure to close any possible open windows, so we show one at a time.
+        await this.close();
+
+        const flattened = this.flatten(this.eventsByHost[host] ?? []);
+        const query = new URLSearchParams();
+        query.append('host', host);
+        query.append('events', JSON.stringify(flattened));
+
+        const win = await browser.windows.create({
+            type: 'detached_panel',
+            width: 400,
+            height: 600,
+            url: `./event-subscription/ui/index.html?${query.toString()}`
+        });
+
+        // Keep track of the new window ID.
+        this.currentWindow = {host, id: win.id!};
+    }
+
+    /**
+     * Closes the currently open window.
+     * (only one window can be open at a time)
+     */
+    async close() {
+        if (this.currentWindow) {
+            await browser.windows.remove(this.currentWindow.id);
+            this.currentWindow = null;
+        }
+    }
+
+    /**
+     * Subscribes to contract events.
+     * TODO: to be implemented.
+     */
+    subscribe(events: string[]) {
+        const contractEvents = this.expand(events);
+        console.log('User wants to subscribe to the following events:');
+        console.log({host: this.currentWindow?.host, contractEvents});
+    }
+
+    /**
+     * Updates preferences in extension storage.
+     */
+    private async updateDoNotAskBefore(host: string, days: number) {
+        const preferences = (await browser.storage.local.get(SUBSCRIPTION_STORAGE_KEY)) as
+            | {[SUBSCRIPTION_STORAGE_KEY]: SubscriptionPreferences}
+            | EmptyObj;
+
+        const updatedPreferences: SubscriptionPreferences = {
+            ...(preferences[SUBSCRIPTION_STORAGE_KEY] ?? {}),
+            [host]: {doNotAskBefore: nowPlusDays(days)}
+        };
+
+        await browser.storage.local.set({[SUBSCRIPTION_STORAGE_KEY]: updatedPreferences});
+    }
+
+    /**
+     * Removes subscription preferences from extension storage.
+     */
+    clearStorage() {
+        void browser.storage.local.remove(SUBSCRIPTION_STORAGE_KEY);
+    }
+
+    /**
+     * Handles event-subscription-related messages from the renderer process.
+     */
+    async handleMessage(message: SubscriptionMessage) {
+        switch (message.method) {
+            case SubscriptionMessageMethod.WINDOW_CLOSE:
+                void this.close();
+                break;
+            case SubscriptionMessageMethod.WINDOW_NOT_AGAIN:
+                await this.updateDoNotAskBefore(this.currentWindow?.host ?? '', 365);
+                void this.close();
+                break;
+            case SubscriptionMessageMethod.WINDOW_LATER:
+                await this.updateDoNotAskBefore(this.currentWindow?.host ?? '', 1);
+                void this.close();
+                break;
+            case SubscriptionMessageMethod.EVENTS_SUBSCRIBE:
+                this.subscribe(message.payload ?? []);
+                void this.close();
+                break;
+            default:
+                console.error(
+                    `[SubscriptionsController]: unknown message method "${JSON.stringify(message)}"`
+                );
+        }
+    }
+}
+
+export default new SubscriptionsController();

--- a/src/event-subscription/types.ts
+++ b/src/event-subscription/types.ts
@@ -1,0 +1,34 @@
+export const SUBSCRIPTION_MESSAGE_TYPE = 'event-subscription';
+export const SUBSCRIPTION_STORAGE_KEY = 'subscription_preferences';
+
+export enum SubscriptionMessageMethod {
+    WINDOW_CLOSE = 'window_close',
+    WINDOW_NOT_AGAIN = 'window_not_again',
+    WINDOW_LATER = 'window_later',
+    EVENTS_SUBSCRIBE = 'events_subscribe'
+}
+
+export type SubscriptionMessage = {
+    __message_type: typeof SUBSCRIPTION_MESSAGE_TYPE;
+    method: SubscriptionMessageMethod;
+    payload?: string[];
+};
+
+export type SubscriptionPreferences = {
+    [host: string]: {
+        doNotAskBefore: string;
+    };
+};
+
+export type ContractEvent = {
+    contractName: string;
+    events: string[];
+};
+
+export type ApiResponse<T> = {
+    status: number;
+    headers: Record<string, unknown>;
+    data: T;
+};
+
+export type EmptyObj = Record<string, never>;

--- a/src/event-subscription/ui/App.tsx
+++ b/src/event-subscription/ui/App.tsx
@@ -1,0 +1,14 @@
+import React, {FunctionComponent} from 'react';
+import {BrowserRouter} from 'react-router-dom';
+import UIThemeProvider from 'pointsdk/theme/UIThemeProvider';
+import Subscriptions from './Subscriptions';
+
+const App: FunctionComponent = () => (
+    <BrowserRouter>
+        <UIThemeProvider>
+            <Subscriptions />
+        </UIThemeProvider>
+    </BrowserRouter>
+);
+
+export default App;

--- a/src/event-subscription/ui/Subscriptions.tsx
+++ b/src/event-subscription/ui/Subscriptions.tsx
@@ -1,0 +1,126 @@
+import React, {useMemo, useState, ChangeEvent} from 'react';
+import {useLocation} from 'react-router-dom';
+import useTheme from '@mui/material/styles/useTheme';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import EventList from './components/EventList';
+import {SubscriptionMessage, SUBSCRIPTION_MESSAGE_TYPE, SubscriptionMessageMethod} from '../types';
+
+const Subscriptions = () => {
+    const theme = useTheme();
+    const [selectedEvents, setSelectedEvents] = useState<string[]>([]);
+    const {search} = useLocation();
+    const query = useMemo(() => new URLSearchParams(search), [search]);
+
+    const events = useMemo(() => {
+        try {
+            return JSON.parse(query.get('events') ?? '[]') as string[];
+        } catch {
+            return [];
+        }
+    }, [query]);
+
+    const handleClose = () => {
+        const msg: SubscriptionMessage = {
+            __message_type: SUBSCRIPTION_MESSAGE_TYPE,
+            method: SubscriptionMessageMethod.WINDOW_CLOSE
+        };
+        void browser.runtime.sendMessage(msg);
+    };
+
+    const handleSubscribe = () => {
+        const msg: SubscriptionMessage = {
+            __message_type: SUBSCRIPTION_MESSAGE_TYPE,
+            method: SubscriptionMessageMethod.EVENTS_SUBSCRIBE,
+            payload: selectedEvents
+        };
+        void browser.runtime.sendMessage(msg);
+    };
+
+    const handleDoNotShow = () => {
+        const msg: SubscriptionMessage = {
+            __message_type: SUBSCRIPTION_MESSAGE_TYPE,
+            method: SubscriptionMessageMethod.WINDOW_NOT_AGAIN
+        };
+        void browser.runtime.sendMessage(msg);
+    };
+
+    const handleShowLater = () => {
+        const msg: SubscriptionMessage = {
+            __message_type: SUBSCRIPTION_MESSAGE_TYPE,
+            method: SubscriptionMessageMethod.WINDOW_LATER
+        };
+        void browser.runtime.sendMessage(msg);
+    };
+
+    const handleSelectOne = (ev: ChangeEvent<HTMLInputElement>) => {
+        if (ev.target.checked) {
+            setSelectedEvents(prev => [...prev, ev.target.name]);
+        } else {
+            setSelectedEvents(prev => prev.filter(i => i !== ev.target.name));
+        }
+    };
+
+    const handleSelectAll = (events: string[]) => {
+        setSelectedEvents(events);
+    };
+
+    return (
+        <Box
+            display="flex"
+            flexDirection="column"
+            p={2}
+            justifyContent="center"
+            alignItems="center"
+            height="100vh"
+        >
+            <Typography
+                variant="h4"
+                fontWeight="bold"
+                color={theme.palette.primary.main}
+                mb={3}
+                textAlign="center"
+            >
+                {query.get('host')}
+            </Typography>
+            <Typography variant="body1" mb={2} textAlign="center">
+                Would you like to receive notifications from {query.get('host')}?
+            </Typography>
+            <Typography variant="body1" mb={2} textAlign="center">
+                Choose the events you&apos;d like to subscribe to:
+            </Typography>
+
+            <EventList
+                events={events}
+                selected={selectedEvents}
+                onSelectOne={handleSelectOne}
+                onSelectAll={handleSelectAll}
+            />
+
+            <Box display="flex" gap={1} mt={6}>
+                <Button
+                    variant="contained"
+                    onClick={handleSubscribe}
+                    disabled={selectedEvents.length === 0}
+                >
+                    Subscribe
+                </Button>
+                <Button variant="outlined" onClick={handleClose}>
+                    Close
+                </Button>
+            </Box>
+
+            <Box mt={3} display="flex" flexDirection="column" alignItems="center">
+                <Button variant="text" onClick={handleShowLater}>
+                    Remind me later
+                </Button>
+                <Button variant="text" onClick={handleDoNotShow}>
+                    Don&apos;t show again for {query.get('host')}
+                </Button>
+            </Box>
+        </Box>
+    );
+};
+
+export default Subscriptions;

--- a/src/event-subscription/ui/components/EventList.tsx
+++ b/src/event-subscription/ui/components/EventList.tsx
@@ -1,0 +1,67 @@
+import React, {useState, ChangeEvent} from 'react';
+import Box from '@mui/material/Box';
+import FormGroup from '@mui/material/FormGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+
+type Props = {
+    events: string[];
+    selected: string[];
+    onSelectOne: (ev: ChangeEvent<HTMLInputElement>) => void;
+    onSelectAll: (events: string[]) => void;
+};
+
+const EventList = ({events, selected, onSelectOne, onSelectAll}: Props) => {
+    const [allSelected, setAllSelected] = useState(false);
+
+    const handleSelectAll = (ev: ChangeEvent<HTMLInputElement>) => {
+        onSelectAll(ev.target.checked ? events : []);
+        setAllSelected(ev.target.checked);
+    };
+
+    return (
+        <Box maxHeight="40vh" overflow="auto" px={2}>
+            {events.map(e => {
+                const parts = e.split(':');
+                if (parts.length < 2) {
+                    return null;
+                }
+                const contractName = parts.shift()!;
+                const eventName = parts.join(':');
+
+                return (
+                    <FormGroup key={e}>
+                        <FormControlLabel
+                            label={eventName}
+                            title={`From contract ${contractName}`}
+                            control={
+                                <Checkbox
+                                    name={e}
+                                    checked={selected.includes(e)}
+                                    onChange={onSelectOne}
+                                />
+                            }
+                        />
+                    </FormGroup>
+                );
+            })}
+
+            {events.length > 1 ? (
+                <FormGroup>
+                    <FormControlLabel
+                        label="Select All"
+                        control={
+                            <Checkbox
+                                name="select-all"
+                                checked={allSelected}
+                                onChange={handleSelectAll}
+                            />
+                        }
+                    />
+                </FormGroup>
+            ) : null}
+        </Box>
+    );
+};
+
+export default EventList;

--- a/src/event-subscription/ui/index.html
+++ b/src/event-subscription/ui/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>Point Event Subscription</title>
+  <!-- <script src="../../pointsdk/pageMessaging.js"></script> -->
+  <script src="index.js"></script>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+  </style>
+</head>
+<body>
+  <div id="point-event-subscription"></div>
+</body>
+</html>
+

--- a/src/event-subscription/ui/index.tsx
+++ b/src/event-subscription/ui/index.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import App from './App';
+import getSdk from 'pointsdk/pointsdk/sdk';
+
+const version = browser.runtime.getManifest().version;
+const point = getSdk('https://event-subscription', version, null);
+
+const renderWindow = () => {
+    try {
+        window.point = point;
+        ReactDOM.render(<App />, document.getElementById('point-event-subscription'));
+    } catch (e) {
+        console.error('Failed to render event subscription window', e);
+    }
+};
+
+document.addEventListener('DOMContentLoaded', renderWindow);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,6 +22,7 @@
   "permissions": [
     "<all_urls>",
     "tabs",
+    "history",
     "activeTab",
     "storage",
     "webRequest"
@@ -51,6 +52,8 @@
     "popup/index.tsx",
     "confirmation-window/index.html",
     "confirmation-window/index.tsx",
+    "event-subscription/ui/index.html",
+    "event-subscription/ui/index.tsx",
     "pointsdk/pageMessaging.ts"
   ]
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,18 @@
+/**
+ * Calculates today + a given number of days and returns the result as a UTC string.
+ */
+export function nowPlusDays(days: number): string {
+    const now = new Date();
+    now.setDate(now.getDate() + days);
+    return now.toUTCString();
+}
+
+/**
+ * Calculates if today is after a given limit.
+ * The limit must be a valid date string.
+ */
+export function nowIsAfter(limit: string): boolean {
+    const limitDate = new Date(limit);
+    const today = new Date();
+    return today > limitDate;
+}


### PR DESCRIPTION
**NOTE**: The feature is disabled as it's not fully functional. To enable it, for testing for example, uncomment [this line](https://github.com/pointnetwork/pointsdk/blob/PN-272/src/background/index.ts#L74).

---

These changes provide an initial integration of event subscription, namely:
- using the `history` api, we detect visits to dApps and ask Point Engine for a list of events
- if there are any events, they are presented to the user with a checkbox next to each other (for now, the UI is a _detached panel_, same as the confirmation window)
- the events are cached so that we don't ask Point Engine multiple times the same thing
- selected events are communicated from the UI to the background process, and this is as far as the functionality goes right now, the events are logged to the console, no subscriptions are made.
- instead of selecting events, users can simply close the window; they can also choose to be reminded later or not to be asked again (these preferences work on a host/dApp level)
- the "ask me later / don't ask me again" preferences are stored in extension storage and checked before rendering the UI

I think that this functionality, and even the elements of the UI, are probably going to be useful regardless of the exact implementation we land on. So, I'm submitting this PR for consideration.